### PR TITLE
Seems to fix ammo merge error

### DIFF
--- a/lib/models/Character.js
+++ b/lib/models/Character.js
@@ -612,6 +612,7 @@ class Character extends BaseModel {
         if (destinationItem) {
             const mergedItem = await this.getInventoryItemByID(mergedStackId);
             if (mergedItem) {
+                if (!mergedItem.upd) mergedItem["upd"] = {};
                 if (!mergedItem.upd.StackObjectsCount) {
                     mergedItem.upd.StackObjectsCount = 1;
                 }


### PR DESCRIPTION
I guess it can see ``upd.StackObjectsCount`` now. If its shit, its mostly Kings fault. Seems to work for me though.