### PR TITLE
Working, less intrusive, autoupdate.

### DIFF
--- a/lib/ext/update.mjs
+++ b/lib/ext/update.mjs
@@ -1,50 +1,40 @@
-process.removeAllListeners('warning')
 import { createWriteStream, existsSync } from 'fs';
 import fetch from 'node-fetch'; 
 import { Octokit } from '@octokit/rest'; 
 import { fullArchive } from 'node-7z-archive';
 import readline from 'readline';
+import dns from 'dns/promises';
+
+process.removeAllListeners('warning');
 
 const checkInternet = async () => {
-  return dns.lookup('google.com')
-      .then(() => {
-          return true;
-      })
-      .catch(() => {
-          return false;
-      });
+  try {
+    await dns.lookup('google.com');
+    return true;
+  } catch (error) {
+    return false;
+  }
 };
 
-if (!checkInternet) {
-  console.log("Your not connected to the internet! Cannot update!")
-  import("../../app");
-if(!existsSync("./updatebypass.json")) { //simple bypass until we figure out what the fuck we doing with configs
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
-
-rl.question('An update is available. Do you want to update? (yes/no)', answer => {
-  if (answer.toLowerCase() === "yes") {
-    checkForUpdates();
-  } else {
-    console.log("Update cancelled.");
-    import("../../app.js");
-  }
-  rl.close();
-});}}
-else {
-  import("../../app.js");
+if (!await checkInternet()) {
+  console.log("You're not connected to the internet! Cannot update!");
+  import("../../app.mjs");
+} else if (!existsSync("./updatebypass.json")) { //simple bypass until we figure out what the fuck we're doing with configs
+  checkForUpdates();
+} else {
+  import("../../app.mjs");
 }
 
-const octokit = new Octokit();
+
+
+/**
+ * Checks for update using Octokit. 
+ */
+async function checkForUpdates() {
+  const octokit = new Octokit();
 
 const owner = 'Make-Tarkov-Great-Again';
 const repo = 'MTGA-Releases';
-    /**
-     * Checks for update using Octokit. 
-     */
-export async function checkForUpdates() {
   try {
     // Get the latest release information from GitHub
     const { data: latestRelease } = await octokit.repos.getLatestRelease({ owner, repo });
@@ -54,28 +44,34 @@ export async function checkForUpdates() {
     const latestVersion = latestRelease.tag_name.replace(/^v/, ''); // Latest version of MTGA
 
     if (latestVersion !== currentVersion) { // Check if there is a new version of MTGA available
-      console.log(`New version available: ${latestVersion}`);
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+      });
+      
+      rl.question(`Update ${latestVersion} is available. Do you want to update now? (y/n)\n\n`, async (answer) => {
+        if (answer.toLowerCase() === "yes" || answer.toLowerCase() === "y") {
+          // Download and install the latest release
+          const downloadUrl = latestRelease.assets[0].browser_download_url; // URL to download the latest release
+          const fileType = latestRelease.assets[0].content_type; // Type of the downloaded file
+          const fileName = latestRelease.assets[0].name; // Name of the downloaded file
+          const fileSize = latestRelease.assets[0].size;
 
-      // Download and install the latest release
-      const downloadUrl = latestRelease.assets[0].browser_download_url; // URL to download the latest release
-      const fileType = latestRelease.assets[0].content_type; // Type of the downloaded file
-      const fileName = latestRelease.assets[0].name; // Name of the downloaded file
-      const fileSize = latestRelease.assets[0].size;
-
-      await downloadAndInstallUpdate(downloadUrl, fileName, fileSize);
-      console.log("\n\nDownloaded the newest MTGA version.");
-
-      import("../../app.js");
+          await downloadAndInstallUpdate(downloadUrl, fileName, fileSize);
+          console.log("\n\nDownloaded the newest MTGA version.");
+        } else {
+          console.log("Update cancelled.");
+          rl.close();
+          import("../../app.mjs");
+        }
+      });
     } else {
       console.log('\nMTGA is up to date!');
-      import("../../app.js");
+      import("../../app.mjs");
     }
   } catch (error) {
-    //if {config.debug} {
-    // console.error('\n\nError checking for update: \n\n', error);
-    console.log("We encountered a error!!!!" + `\n\n\n ${error}`)
-    //}
-    import("../../app.js");
+    console.log("We encountered an error!!!!" + `\n\n\n ${error}`);
+    import("../../app.mjs");
   }
 }
     /**
@@ -121,6 +117,7 @@ async function downloadAndInstallUpdate(downloadUrl, fileName, fileSize) {
     // When all is done
     .then(function () {
       console.log('Extracting done!');
+      import("../../app.mjs");
     })
     
     // On error

--- a/lib/ext/update.mjs
+++ b/lib/ext/update.mjs
@@ -1,0 +1,148 @@
+process.removeAllListeners('warning')
+import { createWriteStream, existsSync } from 'fs';
+import fetch from 'node-fetch'; 
+import { Octokit } from '@octokit/rest'; 
+import { fullArchive } from 'node-7z-archive';
+import readline from 'readline';
+
+const checkInternet = async () => {
+  return dns.lookup('google.com')
+      .then(() => {
+          return true;
+      })
+      .catch(() => {
+          return false;
+      });
+};
+
+if (!checkInternet) {
+  console.log("Your not connected to the internet! Cannot update!")
+  import("../../app");
+if(!existsSync("./updatebypass.json")) { //simple bypass until we figure out what the fuck we doing with configs
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+rl.question('An update is available. Do you want to update? (yes/no)', answer => {
+  if (answer.toLowerCase() === "yes") {
+    checkForUpdates();
+  } else {
+    console.log("Update cancelled.");
+    import("../../app.js");
+  }
+  rl.close();
+});}}
+else {
+  import("../../app.js");
+}
+
+const octokit = new Octokit();
+
+const owner = 'Make-Tarkov-Great-Again';
+const repo = 'MTGA-Releases';
+    /**
+     * Checks for update using Octokit. 
+     */
+export async function checkForUpdates() {
+  try {
+    // Get the latest release information from GitHub
+    const { data: latestRelease } = await octokit.repos.getLatestRelease({ owner, repo });
+
+    // Compare the latest release version with the current version of MTGA
+    const currentVersion = process.env.npm_package_version; // Current version of MTGA
+    const latestVersion = latestRelease.tag_name.replace(/^v/, ''); // Latest version of MTGA
+
+    if (latestVersion !== currentVersion) { // Check if there is a new version of MTGA available
+      console.log(`New version available: ${latestVersion}`);
+
+      // Download and install the latest release
+      const downloadUrl = latestRelease.assets[0].browser_download_url; // URL to download the latest release
+      const fileType = latestRelease.assets[0].content_type; // Type of the downloaded file
+      const fileName = latestRelease.assets[0].name; // Name of the downloaded file
+      const fileSize = latestRelease.assets[0].size;
+
+      await downloadAndInstallUpdate(downloadUrl, fileName, fileSize);
+      console.log("\n\nDownloaded the newest MTGA version.");
+
+      import("../../app.js");
+    } else {
+      console.log('\nMTGA is up to date!');
+      import("../../app.js");
+    }
+  } catch (error) {
+    //if {config.debug} {
+    // console.error('\n\nError checking for update: \n\n', error);
+    console.log("We encountered a error!!!!" + `\n\n\n ${error}`)
+    //}
+    import("../../app.js");
+  }
+}
+    /**
+     * Downloads and installs the updates
+     */
+async function downloadAndInstallUpdate(downloadUrl, fileName, fileSize) {
+  const destPath = `./${fileName}`;
+
+  const response = await fetch(downloadUrl);
+  const totalSize = response.headers.get('content-length');
+  let downloadedSize = 0;
+
+  response.body.on('data', chunk => {
+    downloadedSize += chunk.length;
+    const progress = (downloadedSize / totalSize * 100).toFixed(2);
+    process.stdout.write(`Downloading ${progress}%\r`);
+  });
+
+  const dest = createWriteStream(destPath);
+  response.body.pipe(dest);
+
+  await new Promise((resolve) => {
+    dest.on('finish', resolve);
+  });
+
+  console.log(`Downloaded update to ${destPath}`);
+
+  const fileTypeT = fileName.split(".");
+
+  if (fileTypeT[1] === "zip" || fileTypeT[1] === "rar" || fileTypeT[1] === "7z") {
+    console.log('Extracting update...');
+
+    // Set up progress bar for extraction
+
+    // Extract the file using the 7z binary and update progress bar as extraction progresses
+    const filepath = destPath;
+    console.log("./test")
+    fullArchive(`${destPath}`)
+    .progress(function (files) {
+      console.log('Some files are extracted: %s', files);
+    })
+    
+    // When all is done
+    .then(function () {
+      console.log('Extracting done!');
+    })
+    
+    // On error
+    .catch(function (err) {
+      console.error(err);
+    });
+
+  }
+  else if (fileTypeT === "exe") {
+    const childProcess = spawn(`./${fileName}`);
+
+    childProcess.stdout.on('data', (data) => {
+      //console.log(`stdout: ${data}`);
+    });
+
+    childProcess.stderr.on('data', (data) => {
+      console.error(`stderr: ${data}`);
+    });
+
+    childProcess.on('close', (code) => {
+      console.log(`child process exited with code ${code}`);
+      console.log("Should of extracted using Self-Extracting exe.")
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "mtga-server",
   "version": "0.0.1",
   "description": "Make Tarkov Great Again: An `Escape from Tarkov` emulation server built with Fastify",
-  "main": "lib/ext/update.mjs",
+  "main": "./lib/ext/update.mjs",
   "type": "module",
   "scripts": {
-    "start": "node --trace-warnings lib/ext/update.mjs",
-    "dev": "node --trace-warnings --watch app.mjs",
+    "start": "node --trace-warnings ./lib/ext/update.mjs",
+    "dev": "nodemon --trace-warnings app.mjs",
     "transpile": "webpack --config ./deploy/webpack.config.mjs",
     "package": "node ./deploy/pkg.config.mjs",
     "compress": "node ./deploy/7zip.config.mjs",
@@ -17,27 +17,27 @@
   "license": "ISC",
   "dependencies": {
     "@fastify/autoload": "^5.7.1",
-    "@fastify/compress": "^6.2.0",
+    "@fastify/compress": "^6.2.1",
     "@fastify/cookie": "^8.3.0",
     "@fastify/formbody": "^7.4.0",
-    "@fastify/websocket": "^7.1.3",
+    "@fastify/websocket": "^7.2.0",
     "@octokit/rest": "^19.0.7",
     "@xhayper/discord-rpc": "^1.0.15",
-    "console-png": "^1.2.1",
     "fast-stringify": "^2.0.0",
-    "fastify": "^4.14.1",
+    "fastify": "^4.15.0",
     "fastify-plugin": "^4.5.0",
     "json-fixer": "^1.6.15",
     "mongoid-js": "^1.3.0",
-    "node-7z": "^3.0.0",
-    "node-7z-archive": "^1.1.4",
     "pino": "^8.11.0",
-    "selfsigned": "^2.1.1"
+    "selfsigned": "^2.1.1",
+    "terminal-image": "^2.0.0"
   },
   "devDependencies": {
     "@angablue/exe": "^1.2.0",
+    "node-7z-archive": "^1.1.4",
+    "nodemon": "^2.0.22",
     "pino-pretty": "^10.0.0",
-    "webpack": "^5.76.3",
+    "webpack": "^5.77.0",
     "webpack-cli": "^5.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "mtga-server",
   "version": "0.0.1",
   "description": "Make Tarkov Great Again: An `Escape from Tarkov` emulation server built with Fastify",
-  "main": "app.mjs",
+  "main": "lib/ext/update.mjs",
   "type": "module",
   "scripts": {
-    "start": "node --trace-warnings app.mjs",
-    "dev": "nodemon --trace-warnings app.mjs",
+    "start": "node --trace-warnings lib/ext/update.mjs",
+    "dev": "node --trace-warnings --watch app.mjs",
     "transpile": "webpack --config ./deploy/webpack.config.mjs",
     "package": "node ./deploy/pkg.config.mjs",
     "compress": "node ./deploy/7zip.config.mjs",
@@ -17,26 +17,27 @@
   "license": "ISC",
   "dependencies": {
     "@fastify/autoload": "^5.7.1",
-    "@fastify/compress": "^6.2.1",
+    "@fastify/compress": "^6.2.0",
     "@fastify/cookie": "^8.3.0",
     "@fastify/formbody": "^7.4.0",
-    "@fastify/websocket": "^7.2.0",
+    "@fastify/websocket": "^7.1.3",
+    "@octokit/rest": "^19.0.7",
     "@xhayper/discord-rpc": "^1.0.15",
+    "console-png": "^1.2.1",
     "fast-stringify": "^2.0.0",
-    "fastify": "^4.15.0",
+    "fastify": "^4.14.1",
     "fastify-plugin": "^4.5.0",
     "json-fixer": "^1.6.15",
     "mongoid-js": "^1.3.0",
+    "node-7z": "^3.0.0",
+    "node-7z-archive": "^1.1.4",
     "pino": "^8.11.0",
-    "selfsigned": "^2.1.1",
-    "terminal-image": "^2.0.0"
+    "selfsigned": "^2.1.1"
   },
   "devDependencies": {
     "@angablue/exe": "^1.2.0",
-    "node-7z-archive": "^1.1.4",
-    "nodemon": "^2.0.22",
     "pino-pretty": "^10.0.0",
-    "webpack": "^5.77.0",
+    "webpack": "^5.76.3",
     "webpack-cli": "^5.0.1"
   }
 }


### PR DESCRIPTION
This version of auto update is less intrusive, if there is no update, or its bypassed in anyway, it will start in about the same amount of time that it used to. npm run dev still uses app.mjs, to fully bypass, and you can casually bypass it by putting a blank "bypassupdate.json" in the same folder as update.mjs. 

It asks if you want to download the update, if you say yes, or y, it will download and extract the update over its self, update.mjs is designed to get very few changes. Update.mjs is now the main file, this is so you can update app.js if you need to in a update, without fucking something up, or causing corruption/errors, since you know, overriding running code is bad for your soul. 

Build examples (This is after extracting the archive. So make sure to go into where app.mjs is, press ctrl + a, and then add to archive. Dont select a single folder and call it a day, that will not work.)

Good build.
![image](https://user-images.githubusercontent.com/70953258/229259249-f7793496-66b7-4b34-b26a-a508c3930971.png)

Bad build.
![image](https://user-images.githubusercontent.com/70953258/229259254-dcaa1ff9-85f8-485a-9c8e-df73b2976959.png)

Make sure builds are packaged in zip or 7z, the exe one is untested, so it could work lol.





i swear to god if you touch my octokit ima take nehaxs left testicle.